### PR TITLE
Pipeline postcondition fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,17 @@ pipeline {
             }
             post {
                 always {
-                    publishTestResults testResultsPattern: '**/TestResults/*.trx'
+                    // Archive test result files
+                    archiveArtifacts artifacts: '**/TestResults/*.trx', allowEmptyArchive: true
+                    
+                    // Try to publish test results if MSTest plugin is available
+                    script {
+                        try {
+                            step([$class: 'MSTestPublisher', testResultsFile: '**/TestResults/*.trx'])
+                        } catch (Exception e) {
+                            echo "MSTest plugin not available, test results archived only"
+                        }
+                    }
                 }
             }
         }
@@ -79,7 +89,6 @@ pipeline {
             steps {
                 archiveArtifacts artifacts: 'publish\\**\\*.apk', allowEmptyArchive: true
                 archiveArtifacts artifacts: '**/bin/Release/**/*.dll', allowEmptyArchive: true
-                archiveArtifacts artifacts: '**/TestResults/*.trx', allowEmptyArchive: true
             }
         }
     }


### PR DESCRIPTION
1. Removed the problematic publishTestResults step that was causing the NoSuchMethodError
2. Added safe test results publishing using MSTestPublisher with error handling
3. Kept test results archiving so the TRX files are still available
4. Removed duplicate archiving from the Archive APK stage