### PR TITLE
Logs, Initializer, BotRoster

### DIFF
--- a/AutoGladiators.Client/Pages/BotRosterPage.xaml.cs
+++ b/AutoGladiators.Client/Pages/BotRosterPage.xaml.cs
@@ -82,6 +82,9 @@ namespace AutoGladiators.Client.Pages
         {
             base.OnAppearing();
             
+            // Reload bots whenever the page appears to ensure fresh data
+            LoadBots();
+            
             if (_animationManager != null)
             {
                 await _animationManager.AnimatePageEntry(this);
@@ -95,6 +98,8 @@ namespace AutoGladiators.Client.Pages
                 // Get real bot data from GameStateService
                 var gameState = GameStateService.Instance;
                 var realBots = gameState.BotRoster ?? new List<GladiatorBot>();
+                
+                System.Diagnostics.Debug.WriteLine($"BotRosterPage: Loading bots. Found {realBots.Count} bots in GameStateService");
 
                 _allBots = new ObservableCollection<BotSummary>();
                 

--- a/AutoGladiators.Core/Services/EncounterService.cs
+++ b/AutoGladiators.Core/Services/EncounterService.cs
@@ -17,7 +17,7 @@ namespace AutoGladiators.Core.Services.Exploration
     /// </summary>
     public class EncounterService
     {
-        private static readonly Microsoft.Extensions.Logging.ILogger Log = (Microsoft.Extensions.Logging.ILogger)AppLog.For<EncounterService>();
+        private static readonly IAppLogger Log = AppLog.For<EncounterService>();
 
         private readonly Dictionary<string, BiomeData> _biomes;
         private readonly Random _rng = new();
@@ -188,7 +188,7 @@ namespace AutoGladiators.Core.Services.Exploration
             int playerLevel = GetPlayerLevel();
             encounteredBot = GenerateWildBot(selectedEncounter, playerLevel);
             
-            Log.LogInformation($"Wild encounter triggered: {encounteredBot?.Name} in {biome.Name}");
+            Log.Info($"Wild encounter triggered: {encounteredBot?.Name} in {biome.Name}");
             return encounteredBot != null;
         }
         
@@ -415,7 +415,7 @@ namespace AutoGladiators.Core.Services.Exploration
 
     public class WildBotEncounter
     {
-        private static readonly Microsoft.Extensions.Logging.ILogger Log = (Microsoft.Extensions.Logging.ILogger)AppLog.For<EncounterService>();
+        private static readonly IAppLogger Log = AppLog.For<WildBotEncounter>();
 
         public string BotId { get; }
         public Rarity Rarity { get; }


### PR DESCRIPTION
Start Adventure Test: Create new game → Select starter bot → "Start Adventure" should work without TypeInitialization error
Bot Roster Test: After creating character, go to Menu → Bot Roster should show your starter bot (1 bot total)
Log Access Test: Check your Android device's Downloads folder for [AutoGladiators/logs/](vscode-file://vscode-app/c:/Users/Tdanm/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) directory with log files